### PR TITLE
CI: add basic ci and nightly cron

### DIFF
--- a/.github/workflows/ci-casper-rust-contract.yml
+++ b/.github/workflows/ci-casper-rust-contract.yml
@@ -1,0 +1,30 @@
+name: ci-casper-rust-contract
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        components: rustfmt, clippy
+    # Needed for gcc install
+    - run: sudo apt update && sudo apt install -y build-essential
+    - uses: Swatinem/rust-cache@v1
+    - run: make prepare
+    - run: make check-lint
+    - run: make test

--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -1,0 +1,35 @@
+---
+name: nightly-scheduled-test
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # runs every day at midnight
+    - cron: "0 0 * * *"
+
+jobs:
+  nightly-make-test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt, clippy
+
+      # Needed for gcc install
+      - run: sudo apt update && sudo apt install -y build-essential
+      - uses: Swatinem/rust-cache@v1
+      - run: make prepare
+      - run: make test
+
+      - name: Slack Notification
+        uses: ravsamhq/notify-slack-action@v1
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notification_title: "*{repo}*"
+          message_format: "{emoji} *{workflow}* *{status_message}* in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          footer: "<{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Changes:
- Adds basic CI based on `Makefile` for pull/push.
- Adds nightly run of `make test`